### PR TITLE
First PR

### DIFF
--- a/notes.txt
+++ b/notes.txt
@@ -1,0 +1,13 @@
+Totatally replace get random when you can
+
+random is locked in Battle, which Pokemon does not have access to.
+its probably best that we have circular references, like showdown. E.g. pokemon->battle;
+
+Multihit moves have the wrong probablity
+Check on the Psywave rolls
+Implement custom rolls
+Serene Grace (randomChance > 1)
+
+BIG:
+Review ps (repo) first commits. This should show all RNG relevant for ADV
+Implement TransitionData

--- a/notes.txt
+++ b/notes.txt
@@ -6,8 +6,11 @@ its probably best that we have circular references, like showdown. E.g. pokemon-
 Multihit moves have the wrong probablity
 Check on the Psywave rolls
 Implement custom rolls
-Serene Grace (randomChance > 1)
+    Serene Grace (randomChance > 1)
 
 BIG:
 Review ps (repo) first commits. This should show all RNG relevant for ADV
 Implement TransitionData
+
+7/8/22
+Serene Grace, changed all relevant randomChance() calls and boost calls (wrapper for randomChance)

--- a/src/battle/battle.cpp
+++ b/src/battle/battle.cpp
@@ -168,19 +168,6 @@ void Battle::calc_first_attacker(){
     int prio1 = move_prio(this->team[0].movechoice->get_move());
     int prio2 = move_prio(this->team[1].movechoice->get_move());
 
-    // quickclaw holders have a 20% chance to move first in their priority bracket
-    // in singles formats this is equivalent to moving up one priority bracket
-    // if(this->team[0].active()->get_item() == Item::Quickclaw){
-    //     if(get_random(1,10) < 3){
-    //         prio1 += 1;
-    //     }
-    // }    
-    // if(this->team[1].active()->get_item() == Item::Quickclaw){
-    //     if(get_random(1,10) < 3){
-    //         prio2 += 1;
-    //     }
-    // }
-
     // Both claws proc at the same time
     if (this->transition.randomChance(1, 5)) {
         if(this->team[0].active()->get_item() == Item::Quickclaw){

--- a/src/battle/battle.cpp
+++ b/src/battle/battle.cpp
@@ -170,16 +170,28 @@ void Battle::calc_first_attacker(){
 
     // quickclaw holders have a 20% chance to move first in their priority bracket
     // in singles formats this is equivalent to moving up one priority bracket
-    if(this->team[0].active()->get_item() == Item::Quickclaw){
-        if(get_random(1,10) < 3){
+    // if(this->team[0].active()->get_item() == Item::Quickclaw){
+    //     if(get_random(1,10) < 3){
+    //         prio1 += 1;
+    //     }
+    // }    
+    // if(this->team[1].active()->get_item() == Item::Quickclaw){
+    //     if(get_random(1,10) < 3){
+    //         prio2 += 1;
+    //     }
+    // }
+
+    // Both claws proc at the same time
+    if (this->device.randomChance(1, 5)) {
+        if(this->team[0].active()->get_item() == Item::Quickclaw){
             prio1 += 1;
         }
-    }    
-    if(this->team[1].active()->get_item() == Item::Quickclaw){
-        if(get_random(1,10) < 3){
-            prio2 += 1;
-        }
+        if(this->team[1].active()->get_item() == Item::Quickclaw){
+            prio1 += 1;
+        }  
     }
+
+
     if(std::any_of(switches.cbegin(), switches.cend(), [&](Move pSwitch)
                                                         { if(pSwitch == this->team[0].movechoice->get_move())
                                                          { return true;} return false;})){
@@ -233,8 +245,7 @@ bool Battle::compare_speed(){
     }
     if(speed1 < speed2){
         return true;
-    }
-    else{
-        return get_random(0,1);
+    }else{
+        return this->transition.random(2);
     }
 }

--- a/src/battle/battle.cpp
+++ b/src/battle/battle.cpp
@@ -182,7 +182,7 @@ void Battle::calc_first_attacker(){
     // }
 
     // Both claws proc at the same time
-    if (this->device.randomChance(1, 5)) {
+    if (this->transition.randomChance(1, 5)) {
         if(this->team[0].active()->get_item() == Item::Quickclaw){
             prio1 += 1;
         }

--- a/src/battle/battle.hpp
+++ b/src/battle/battle.hpp
@@ -9,6 +9,7 @@
 #include "rng.hpp"
 #include "benchmark.hpp"
 #include "weather.hpp"
+#include "transition.hpp"
 
 class Battle{
 public:
@@ -24,6 +25,8 @@ public:
     int weather_turns = 0;
     bool move_first = true;
     bool winner = false; // false: team 1, true: team 2
+
+    Transition transition;
 
     //decide_move.cpp
     void decide_move(Team &team);

--- a/src/battle/damage_calc.cpp
+++ b/src/battle/damage_calc.cpp
@@ -48,7 +48,8 @@ int Battle::calculate_damage(const Team &atkteam, Team &defteam){
         damage = static_cast<int>(static_cast<float>(damage) * 1.5f);
     }
     damage = static_cast<int>(static_cast<float>(damage) * effectiveness_multiplier(atkteam, defteam));
-    damage = static_cast<int>(static_cast<float>(damage) * static_cast<float>(get_random(85, 100)) / 100.0f);
+    // Need to implement custom damage rolls
+    damage = static_cast<int>(static_cast<float>(damage) * static_cast<float>(85 + this->transition.random(16)) / 100.0f);
 
     if(critical_hit){
         defteam.active()->reduce_hp(damage*2);
@@ -66,29 +67,19 @@ bool Battle::is_crit(const Team &atkteam, const Team &defteam){
 
     switch(crit_multiplier(atkteam, defteam)){
         case 0:
-            if(get_random(0, 15) == 0){
-                return true;
-            }
+            return this->transition.randomChance(1, 16);
             break;
         case 1:
-            if(get_random(0, 7) == 0){
-                return true;
-            }
+            return this->transition.randomChance(1, 8);
             break;
         case 2:
-            if(get_random(0, 3) == 0){
-                return true;
-            }
+            return this->transition.randomChance(1, 4);
             break;
         case 3:
-            if(get_random(0, 2) == 0){
-                return true;
-            }
+            return this->transition.randomChance(1, 3);
             break;
         case 4:
-            if(get_random(0, 1) == 0){
-                return true;
-            }
+            return this->transition.randomChance(1, 2);
             break;
         default:
             return false;

--- a/src/battle/decide_move.cpp
+++ b/src/battle/decide_move.cpp
@@ -4,5 +4,5 @@
 // place to implement decision making
 void Battle::decide_move(Team &team){
     team.prev_movechoice = team.movechoice;
-    team.movechoice = team.move_options[get_random(0, static_cast<int>(team.move_options.size()) - 1)];
+    team.movechoice = team.move_options[this->transition.random(static_cast<int>(team.move_options.size()))];
 }

--- a/src/battle/transition.hpp
+++ b/src/battle/transition.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <vector>
+#include <string>
+
+#include "rng.hpp"
+
+class Transition {
+
+public:
+
+    prng device;
+
+    bool randomChance (int numerator, int denominator) {
+        const int x = this->device.random_int(denominator);
+        this->q *= denominator;
+        if (x <= numerator) {
+            this->p *= numerator;
+            return true;
+        } else {
+            this->p *= (denominator - numerator);
+            return false;
+        }
+    }
+
+    // Random integer sampled uniformly from [0, a)
+    int random(int a) {
+        this->q *= a;
+        return this->device.random_int(a);
+    }
+
+    void reset () {
+        this->p = 1;
+        this->q = 1;
+        log_string.clear();
+    }
+
+private:
+    int p = 1;
+    int q = 1;
+    std::vector<std::string> log_string;
+
+}

--- a/src/battle/transition.hpp
+++ b/src/battle/transition.hpp
@@ -40,4 +40,4 @@ private:
     int q = 1;
     std::vector<std::string> log_string;
 
-}
+};

--- a/src/battle/transition.hpp
+++ b/src/battle/transition.hpp
@@ -12,6 +12,9 @@ public:
     prng device;
 
     bool randomChance (int numerator, int denominator) {
+        if (numerator >= denominator) {
+            return true;
+        }
         const int x = this->device.random_int(denominator);
         this->q *= denominator;
         if (x <= numerator) {
@@ -27,6 +30,11 @@ public:
     int random(int a) {
         this->q *= a;
         return this->device.random_int(a);
+    }
+
+    int random(int a, int b) {
+        this->q *= b-a;
+        return a + this->device.random_int(b - a);
     }
 
     void reset () {

--- a/src/battle/turn.cpp
+++ b/src/battle/turn.cpp
@@ -95,7 +95,7 @@ bool Battle::can_move(Team &team){
     switch (team.active()->get_status())
     {
         case Status::Freeze:
-            if(get_random(1,4) == 2){
+            if(this->transition.randomChance(1, 5)){
                 break;
             }
             cant_move_log(team, "frz");
@@ -119,7 +119,7 @@ bool Battle::can_move(Team &team){
                 break;
             }
         case Status::Paralysis:
-            if(get_random(1, 4) == 1){
+            if(this->transition.randomChance(1, 4)){
                 cant_move_log(team, "par");
                 return false;
             }
@@ -130,11 +130,11 @@ bool Battle::can_move(Team &team){
     if(team.truant == true){ return false; }
     // infatuation
     if(team.infatuated){
-        if(get_random(1, 2) == 1){ return false; }
+        if(this->transition.randomChance(1, 2)){ return false; }
     }
     // confusion selfhit
     if(team.confusion > 0){
-        if(get_random(1, 2) == 1){
+        if(this->transition.randomChance(1, 2)){
             team.movechoice->set_move(Move::Hit_Self);
             team.active()->reduce_hp(calculate_damage(team, team));
             return false;
@@ -235,7 +235,7 @@ bool Battle::end_of_turn(){
         }
         // shed skin, 1/3 chance of removing status condition
         if(this->team[first].active()->get_ability() == Ability::Shed_Skin){
-            if(get_random(0,2) > 0){
+            if(this->transition.randomChance(1, 3)){
                 this->team[first].active()->set_status(Status::Healthy, false);
             }
         }

--- a/src/battle/use_move.cpp
+++ b/src/battle/use_move.cpp
@@ -729,7 +729,7 @@ void Battle::use_move(Team &atkteam, Team &defteam){
             boost(atkteam, Statname::Satk, -2, 100, true);
             return;	
 	    case Move::Psywave:
-            dmg = 10 * get_random(0, 10); // Don't recall actual mechanic
+            dmg = 10 * this->transition.random(11); // TODO Confirm this is not '10'
             dmg *= 50;
             dmg *= atkteam.active()->get_level();
             dmg = static_cast<int>(dmg / 100.0);
@@ -761,9 +761,8 @@ void Battle::use_move(Team &atkteam, Team &defteam){
         case Move::Pin_Missile:
         case Move::Rock_Blast:
         case Move::Spike_Cannon:
-            for(int i = 0; i < get_random(2,5); ++i){ // TODO Pretty sure these probs are wrong. Easy fix.
+            for(int i = 0; i < this->transition.random(2, 6); ++i){ // TODO Pretty sure these probs are wrong. Easy fix.
                 calculate_damage(atkteam, defteam);
-                
             }
             return;
         case Move::Bonemerang:

--- a/src/battle/use_move.cpp
+++ b/src/battle/use_move.cpp
@@ -334,14 +334,14 @@ void Battle::use_move(Team &atkteam, Team &defteam){
             calculate_damage(atkteam, defteam);
             
             if(dmg > 0 && defteam.active()->get_ability() != Ability::Shield_Dust){
-                boost(defteam, Statname::Def, -1, 10, false);
+                boost(defteam, Statname::Def, -1, 10 * serene_grace, false);
             }
             return;
         case Move::Ancient_Power:
             calculate_damage(atkteam, defteam);
             
             if(dmg > 0){
-                if(this->transition.randomChance(1, 10)){
+                if(this->transition.randomChance(serene_grace, 10)){
                     defteam.set_boost(Statname::Atk, 1);
                     defteam.set_boost(Statname::Def, 1);
                     defteam.set_boost(Statname::Satk, 1);
@@ -353,7 +353,7 @@ void Battle::use_move(Team &atkteam, Team &defteam){
         case Move::Aurora_Beam:
             calculate_damage(atkteam, defteam);
             
-            boost(defteam, Statname::Atk, 1, 10, false);
+            boost(defteam, Statname::Atk, 1, 10 * serene_grace, false);
             return;
         case Move::Astonish:
         case Move::Bite:
@@ -362,7 +362,7 @@ void Battle::use_move(Team &atkteam, Team &defteam){
             if(dmg > 0 && defteam.active()->get_ability() != Ability::Shield_Dust){
                 
                 if(defteam.active()->get_ability() != Ability::Inner_Focus){   
-                    if(this->transition.randomChance(3, 10)){   
+                    if(this->transition.randomChance(3 * serene_grace, 10)){   
                         defteam.flinch = true;
                     }
                 }
@@ -386,7 +386,7 @@ void Battle::use_move(Team &atkteam, Team &defteam){
             calculate_damage(atkteam, defteam);
             
             if(dmg > 0 && defteam.active()->get_ability() != Ability::Shield_Dust){
-                if(this->transition.randomChance(1, 10)){
+                if(this->transition.randomChance(serene_grace, 10)){
                     // Should have function try_set_status()
                     if(defteam.active()->get_status() == Status::Healthy){
                         defteam.active()->set_status(Status::Burn, defteam.safeguard);
@@ -401,7 +401,7 @@ void Battle::use_move(Team &atkteam, Team &defteam){
             if(dmg > 0 && defteam.active()->get_ability() != Ability::Shield_Dust){
                 
                 if(defteam.active()->get_status() == Status::Healthy){
-                    if(this->transition.randomChance(1, 10)){
+                    if(this->transition.randomChance(serene_grace, 10)){
                         defteam.active()->set_status(Status::Freeze, defteam.safeguard);
                     }
                 }
@@ -413,7 +413,7 @@ void Battle::use_move(Team &atkteam, Team &defteam){
             if(dmg > 0 && defteam.active()->get_ability() != Ability::Shield_Dust){
                 
                 if(defteam.active()->get_status() == Status::Healthy){
-                    if(this->transition.randomChance(3, 10)){
+                    if(this->transition.randomChance(3 * serene_grace, 10)){
                         defteam.active()->set_status(Status::Paralysis, defteam.safeguard);
                     }
                 }
@@ -425,7 +425,7 @@ void Battle::use_move(Team &atkteam, Team &defteam){
             if(dmg > 0 && defteam.active()->get_ability() != Ability::Shield_Dust){
                 
                 if(defteam.active()->get_ability() != Ability::Inner_Focus){   
-                    if(this->transition.randomChance(1, 10)){   
+                    if(this->transition.randomChance(serene_grace, 10)){   
                         defteam.flinch = true;
                     }
                 }
@@ -437,14 +437,14 @@ void Battle::use_move(Team &atkteam, Team &defteam){
             calculate_damage(atkteam, defteam);
             if(dmg > 0 && defteam.active()->get_ability() != Ability::Shield_Dust){
                 
-                boost(defteam, Statname::Spe, -1, 20, false);
+                boost(defteam, Statname::Spe, -1, 10 * serene_grace, false);
             }
             return;
         case Move::Confusion:
             calculate_damage(atkteam, defteam);
             if(dmg > 0 && defteam.active()->get_ability() != Ability::Shield_Dust){
                 
-                if(this->transition.randomChance(1, 10)){
+                if(this->transition.randomChance(serene_grace, 10)){
                     defteam.set_confusion(); // Reminder to look at confusion, sleep, encore, etc
                 }
             }
@@ -453,14 +453,14 @@ void Battle::use_move(Team &atkteam, Team &defteam){
             calculate_damage(atkteam, defteam);
             if(dmg > 0 && defteam.active()->get_ability() != Ability::Shield_Dust){
                 
-                boost(defteam, Statname::Sdef, -1, 30, false);
+                boost(defteam, Statname::Sdef, -1, 30 * serene_grace, false);
             }
             return;
         case Move::Crush_Claw:
             calculate_damage(atkteam, defteam);
             if(dmg > 0 && defteam.active()->get_ability() != Ability::Shield_Dust){
                 
-                boost(defteam, Statname::Def, -1, 50, false);
+                boost(defteam, Statname::Def, -1, 50 * serene_grace, false);
             }
             return;
         case Move::Dizzy_Punch:

--- a/src/battle/use_move.cpp
+++ b/src/battle/use_move.cpp
@@ -65,10 +65,10 @@ void Battle::use_move(Team &atkteam, Team &defteam){
         switch (defteam.active()->get_ability())
         {
         case Ability::Cute_Charm:
-            if(get_random(1, 10) < 4){ atkteam.infatuated = true; }
+            if(this->transition.randomChance(3, 10)){ atkteam.infatuated = true; }
         case Ability::Effect_Spore:
-            if(get_random(1, 10) < 2){
-                switch(get_random(0, 2)){
+            if(this->transition.randomChance(1, 10)){
+                switch(this->transition.random(3)){
                     case 0: atkteam.active()->set_status(Status::Poison, atkteam.safeguard);
                         if(atkteam.active()->get_ability() == Ability::Synchronize){
                             defteam.active()->set_status(Status::Poison, defteam.safeguard);
@@ -86,10 +86,10 @@ void Battle::use_move(Team &atkteam, Team &defteam){
                     break;
                 }
             }break;
-        case Ability::Flame_Body: if(get_random(1, 10) < 4){ atkteam.active()->set_status(Status::Burn, atkteam.safeguard);} break;
-        case Ability::Poison_Point: if(get_random(1, 10) < 4){ atkteam.active()->set_status(Status::Poison, atkteam.safeguard);} break;
+        case Ability::Flame_Body: if(this->transition.randomChance(3, 10)){ atkteam.active()->set_status(Status::Burn, atkteam.safeguard);} break;
+        case Ability::Poison_Point: if(this->transition.randomChance(3, 10)){ atkteam.active()->set_status(Status::Poison, atkteam.safeguard);} break;
         case Ability::Rough_Skin: atkteam.active()->reduce_hp(atkteam.active()->get_stats().hp / 16.0); break;
-        case Ability::Static: if(get_random(1, 10) < 4){ atkteam.active()->set_status(Status::Paralysis, atkteam.safeguard);} break;
+        case Ability::Static: if(this->transition.randomChance(3, 10)){ atkteam.active()->set_status(Status::Paralysis, atkteam.safeguard);} break;
         default:
             break;
         }
@@ -182,7 +182,7 @@ void Battle::use_move(Team &atkteam, Team &defteam){
                 accuracy = static_cast<int>(accuracy * 33 / 100);
                 break;
         }
-        if(get_random(1,100) > accuracy){ 
+        if(!this->transition.randomChance(accuracy, 100)){ 
             miss_log();
             return; 
         };
@@ -341,7 +341,7 @@ void Battle::use_move(Team &atkteam, Team &defteam){
             calculate_damage(atkteam, defteam);
             
             if(dmg > 0){
-                if(get_random(1,10) == 1){
+                if(this->transition.randomChance(1, 10)){
                     defteam.set_boost(Statname::Atk, 1);
                     defteam.set_boost(Statname::Def, 1);
                     defteam.set_boost(Statname::Satk, 1);
@@ -362,7 +362,7 @@ void Battle::use_move(Team &atkteam, Team &defteam){
             if(dmg > 0 && defteam.active()->get_ability() != Ability::Shield_Dust){
                 
                 if(defteam.active()->get_ability() != Ability::Inner_Focus){   
-                    if(get_random(1,10) < 4){   
+                    if(this->transition.randomChance(3, 10)){   
                         defteam.flinch = true;
                     }
                 }
@@ -386,7 +386,8 @@ void Battle::use_move(Team &atkteam, Team &defteam){
             calculate_damage(atkteam, defteam);
             
             if(dmg > 0 && defteam.active()->get_ability() != Ability::Shield_Dust){
-                if(get_random(1,10)){
+                if(this->transition.randomChance(1, 10)){
+                    // Should have function try_set_status()
                     if(defteam.active()->get_status() == Status::Healthy){
                         defteam.active()->set_status(Status::Burn, defteam.safeguard);
                     }
@@ -400,7 +401,7 @@ void Battle::use_move(Team &atkteam, Team &defteam){
             if(dmg > 0 && defteam.active()->get_ability() != Ability::Shield_Dust){
                 
                 if(defteam.active()->get_status() == Status::Healthy){
-                    if(get_random(1,10) < 2){
+                    if(this->transition.randomChance(1, 10)){
                         defteam.active()->set_status(Status::Freeze, defteam.safeguard);
                     }
                 }
@@ -412,7 +413,7 @@ void Battle::use_move(Team &atkteam, Team &defteam){
             if(dmg > 0 && defteam.active()->get_ability() != Ability::Shield_Dust){
                 
                 if(defteam.active()->get_status() == Status::Healthy){
-                    if(get_random(1,10) < 4){
+                    if(this->transition.randomChance(3, 10)){
                         defteam.active()->set_status(Status::Paralysis, defteam.safeguard);
                     }
                 }
@@ -424,7 +425,7 @@ void Battle::use_move(Team &atkteam, Team &defteam){
             if(dmg > 0 && defteam.active()->get_ability() != Ability::Shield_Dust){
                 
                 if(defteam.active()->get_ability() != Ability::Inner_Focus){   
-                    if(get_random(1,10) < 2){   
+                    if(this->transition.randomChance(1, 10)){   
                         defteam.flinch = true;
                     }
                 }
@@ -443,8 +444,8 @@ void Battle::use_move(Team &atkteam, Team &defteam){
             calculate_damage(atkteam, defteam);
             if(dmg > 0 && defteam.active()->get_ability() != Ability::Shield_Dust){
                 
-                if(get_random(1,10) < 2){
-                    defteam.set_confusion();
+                if(this->transition.randomChance(1, 10)){
+                    defteam.set_confusion(); // Reminder to look at confusion, sleep, encore, etc
                 }
             }
             return;
@@ -728,7 +729,7 @@ void Battle::use_move(Team &atkteam, Team &defteam){
             boost(atkteam, Statname::Satk, -2, 100, true);
             return;	
 	    case Move::Psywave:
-            dmg = 10 * get_random(0, 10);
+            dmg = 10 * get_random(0, 10); // Don't recall actual mechanic
             dmg *= 50;
             dmg *= atkteam.active()->get_level();
             dmg = static_cast<int>(dmg / 100.0);
@@ -760,7 +761,7 @@ void Battle::use_move(Team &atkteam, Team &defteam){
         case Move::Pin_Missile:
         case Move::Rock_Blast:
         case Move::Spike_Cannon:
-            for(int i = 0; i < get_random(2,5); ++i){
+            for(int i = 0; i < get_random(2,5); ++i){ // TODO Pretty sure these probs are wrong. Easy fix.
                 calculate_damage(atkteam, defteam);
                 
             }
@@ -833,7 +834,7 @@ void Battle::use_move(Team &atkteam, Team &defteam){
             calculate_damage(atkteam, defteam);
             if(dmg <= 0){ return; }
             
-            if(defteam.wrap <= 0){ defteam.wrap = get_random(2, 5); }
+            if(defteam.wrap <= 0){ defteam.wrap = get_random(2, 5); } // Need to lookup
         case Move::Block:
         case Move::Mean_Look:
         case Move::Spider_Web:
@@ -1242,7 +1243,7 @@ void Battle::use_move(Team &atkteam, Team &defteam){
                     }
                 }
                 if(targets.size() > 1){
-                    switchIn(defteam, atkteam, get_random(0, targets.size() - 1));
+                    switchIn(defteam, atkteam, this->transition.random(targets.size()));
                 }
             }
             return;

--- a/src/battle/use_move.cpp
+++ b/src/battle/use_move.cpp
@@ -11,7 +11,8 @@ void Battle::use_move(Team &atkteam, Team &defteam){
                 return;
             }
         }
-        if(get_random(1, 100) <= chance){
+        // "this" Might cause issue
+        if(this->transition.randomChance(chance, 100)){
             team.set_boost(stat, boost);
         }
     };

--- a/src/battle/use_move.cpp
+++ b/src/battle/use_move.cpp
@@ -2,7 +2,7 @@
 
 
 void Battle::use_move(Team &atkteam, Team &defteam){ 
-    auto boost = [](Team &team, const Statname stat, const int boost, const int chance, bool self){
+    auto boost = [&](Team &team, const Statname stat, const int boost, const int chance, bool self){
         if(stat == Statname::Acc && team.active()->get_ability() == Ability::Keen_Eye){ return; }
         if(team.active()->get_ability() == Ability::Clear_Body 
            || team.active()->get_ability() == Ability::White_Smoke

--- a/src/pokemon/pokemon.cpp
+++ b/src/pokemon/pokemon.cpp
@@ -101,7 +101,7 @@ void Pokemon::set_status(const Status p_status, const bool safeguard){
         this->sleep_turns = 2;
     }
     if(p_status == Status::Sleep_inflicted){
-        this->sleep_turns = get_random(2,5);
+        this->sleep_turns = get_random(2,5); // TODO
     }
 }
 

--- a/src/team/team.cpp
+++ b/src/team/team.cpp
@@ -230,7 +230,7 @@ void Team::use_pinch_berry(){
 void Team::set_confusion(){
     if(this->active()->get_ability() == Ability::Own_Tempo){ return; }
     if(this->confusion < 1){
-        this->confusion = get_random(2,5);
+        this->confusion = get_random(2,5); // TODO Needs major overhaul
     }
 }
 

--- a/src/tools/rng.cpp
+++ b/src/tools/rng.cpp
@@ -1,5 +1,7 @@
 #include "rng.hpp"
 
+
+// TODO Remove this. Only needed by non battle objects.
 int get_random(int a = 0, int b = 100){
     
     static auto engine = std::mt19937(std::random_device()());
@@ -7,4 +9,39 @@ int get_random(int a = 0, int b = 100){
     auto const random_number = distribution(engine);
 
     return random_number;
+}
+
+prng::prng () :
+seed(std::random_device{}()), engine(std::mt19937 {seed}) {}
+prng::prng (std::mt19937::result_type seed) : 
+seed(seed), engine(std::mt19937 {seed}) {}
+
+// Same device and seed, but 'restarted'
+// Default copy keeps progress
+prng prng :: copy () {
+    return prng(seed);
+}
+
+std::mt19937::result_type prng :: get_seed () {
+    return seed;
+}
+
+double prng :: uniform () {
+    return uniform_(engine);
+}
+
+int prng :: random_int (int n) {
+    return int (this->uniform() * n);
+}
+
+// samples an index from a probability distribution
+int prng :: sample_pdf (double* input, int k) {
+    double p = this->uniform();
+    for (int i = 0; i < k; ++i) {
+        p -= input[i];
+        if (p <= 0) {
+            return i;
+        }
+    }
+    return 0;
 }

--- a/src/tools/rng.cpp
+++ b/src/tools/rng.cpp
@@ -1,14 +1,10 @@
 #include "rng.hpp"
 
-// int get_random(int a = 0, int b = 100){
+int get_random(int a = 0, int b = 100){
     
-//     static auto engine = std::mt19937(std::random_device()());
-//     auto distribution = std::uniform_int_distribution<>(a, b);
-//     auto const random_number = distribution(engine);
+    static auto engine = std::mt19937(std::random_device()());
+    auto distribution = std::uniform_int_distribution<>(a, b);
+    auto const random_number = distribution(engine);
 
-//     return random_number;
-// }
-
-// bool randomChance(int p, int q) {
-
-// }
+    return random_number;
+}

--- a/src/tools/rng.cpp
+++ b/src/tools/rng.cpp
@@ -1,10 +1,14 @@
 #include "rng.hpp"
 
-int get_random(int a = 0, int b = 100){
+// int get_random(int a = 0, int b = 100){
     
-    static auto engine = std::mt19937(std::random_device()());
-    auto distribution = std::uniform_int_distribution<>(a, b);
-    auto const random_number = distribution(engine);
+//     static auto engine = std::mt19937(std::random_device()());
+//     auto distribution = std::uniform_int_distribution<>(a, b);
+//     auto const random_number = distribution(engine);
 
-    return random_number;
-}
+//     return random_number;
+// }
+
+// bool randomChance(int p, int q) {
+
+// }

--- a/src/tools/rng.hpp
+++ b/src/tools/rng.hpp
@@ -1,5 +1,9 @@
+#pragma once
+
 #include <random>
 #include <array>
+
+int get_random (int a, int b);
 
 class prng {
     std::mt19937::result_type seed;

--- a/src/tools/rng.hpp
+++ b/src/tools/rng.hpp
@@ -12,40 +12,21 @@ class prng {
     
 public:
 
-    prng () :
-    seed(std::random_device{}()), engine(std::mt19937 {seed}) {}
-    prng (std::mt19937::result_type seed) : 
-    seed(seed), engine(std::mt19937 {seed}) {}
+    prng ();
+    prng (std::mt19937::result_type seed);
 
     // Same device and seed, but 'restarted'
     // Default copy keeps progress
-    prng copy () {
-        return prng(seed);
-    }
+    prng copy ();
 
-    std::mt19937::result_type get_seed () {
-        return seed;
-    }
+    std::mt19937::result_type get_seed ();
 
-    double uniform () {
-        return uniform_(engine);
-    }
+    double uniform ();
 
-    int random_int (int n) {
-        return int (this->uniform() * n);
-    }
+    int random_int (int n);
 
     // samples an index from a probability distribution
-    int sample_pdf (double* input, int k) {
-        double p = this->uniform();
-        for (int i = 0; i < k; ++i) {
-            p -= input[i];
-            if (p <= 0) {
-                return i;
-            }
-        }
-        return 0;
-    }
+    int sample_pdf (double* input, int k);
 
     template <typename T, int size>
     int sample_pdf (std::array<T, size> input, int k) {

--- a/src/tools/rng.hpp
+++ b/src/tools/rng.hpp
@@ -1,5 +1,57 @@
-#pragma once
-
 #include <random>
+#include <array>
 
-int get_random(int a, int b);
+class prng {
+    std::mt19937::result_type seed;
+    std::mt19937 engine;
+    std::uniform_real_distribution<double> uniform_;
+    
+public:
+
+    prng () :
+    seed(std::random_device{}()), engine(std::mt19937 {seed}) {}
+    prng (std::mt19937::result_type seed) : 
+    seed(seed), engine(std::mt19937 {seed}) {}
+
+    // Same device and seed, but 'restarted'
+    // Default copy keeps progress
+    prng copy () {
+        return prng(seed);
+    }
+
+    std::mt19937::result_type get_seed () {
+        return seed;
+    }
+
+    double uniform () {
+        return uniform_(engine);
+    }
+
+    int random_int (int n) {
+        return int (this->uniform() * n);
+    }
+
+    // samples an index from a probability distribution
+    int sample_pdf (double* input, int k) {
+        double p = this->uniform();
+        for (int i = 0; i < k; ++i) {
+            p -= input[i];
+            if (p <= 0) {
+                return i;
+            }
+        }
+        return 0;
+    }
+
+    template <typename T, int size>
+    int sample_pdf (std::array<T, size> input, int k) {
+        double p = uniform();
+        for (int i = 0; i < k; ++i) {
+            p -= input[i];
+            if (p <= 0) {
+                return i;
+            }
+        }
+        return 0;
+    }
+};


### PR DESCRIPTION
Transition added to Battle, updated most RNG calls to use Transition's methods.
Half Fixed Quick Claw (It sets speed to cart int max, not priority). This should be finished, since currently quick claw can beat priority, which it shouldn't.
Fixed thaw rate from 1/4 to 1/5
It looks like it might still be broken? Where does it thaw?

Battle::use_move I changed the lambda to use [&], since I want to call this from within.
This should be changed to only include this, and not all names.
